### PR TITLE
fix: ensure hardware arrow keys function on iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
 # flutter_webview_arrow_keys
 
-A Flutter project to demonstrate the arrow keys issue in [webview_flutter](https://pub.dev/packages/webview_flutter).
+This Flutter project demonstrates a work-around that enables hardware arrow keys in [webview_flutter](https://pub.dev/packages/webview_flutter).
 
 ## Issue
 
-The issue is that the arrow keys do not work in [webview_flutter](https://pub.dev/packages/webview_flutter). This is a problem for Flutter applications that run on iOS, Android or Chromebook. The keyboard arrow keys don't work in webview content.
+Without this work-around hardware arrow keys do not work in [webview_flutter](https://pub.dev/packages/webview_flutter), as is outlined in https://github.com/flutter/flutter/issues/102505. 
 
-## Reproduce
+The issue occurs on the following platforms:
 
-1. Run this project on an iOS, Android or Chromebook device with keyboard
-2. Enter text in the search text field and use left and right keyboard arrow keys to move the cursor
-3. Expected: cursor moves left and right
-4. Actual: cursor does not move
+1. Android with a hardware keyboard attached
+2. Chromebook with hardware keyboard
+3. iOS with a hardware keyboard attached
 
-## Device configuation
+## Solution
 
-We could reproduce this issue on the following devices:
-1. iOS iPad with bluetooth keyboard attached
-2. Android tablet with usb keyboard attached
-3. Chromebook with keyboard
+Apparently the arrow keys from the hardware keyboard get "eaten" by Flutter and never reach the included webview. By listening to the arrow keys and instructing Flutter to return them to the platform the arrow keys function again.
+
+## Reproduction of the issue
+
+_Note: this issue was tested on Flutter 3.10.6._
+
+1. Clone this project.
+2. Disable the `onKey` handler of the `Focus` node.
+3. Run the project on an iOS, Android or Chromebook device with a hardware keyboard.
+4. Enter text in the search text field and use left and right keyboard arrow keys to move the cursor.
+5. Expected: cursor moves left and right.
+6. Actual: cursor does not move.
 
 ## Related issue
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,8 @@ class MyApp extends StatelessWidget {
       home: Focus(
         onKey: (node, event) {
           // Allow webview to handle cursor keys. Without this, the
-          // arrow keys disappear before they reach the webview
+          // arrow keys seem to get "eaten" by Flutter and therefore
+          // never reach the webview.
           // (https://github.com/flutter/flutter/issues/102505).
           if (!kIsWeb) {
             if (event.isKeyPressed(LogicalKeyboardKey.arrowLeft) ||

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 void main() {
@@ -11,12 +13,29 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: WebViewWidget(
-        controller: WebViewController()
-          ..setJavaScriptMode(JavaScriptMode.unrestricted)
-          ..loadRequest(
-            Uri.parse('https://www.duckduckgo.com'),
-          ),
+      home: Focus(
+        onKey: (node, event) {
+          // Allow webview to handle cursor keys. Without this, the
+          // arrow keys disappear before they reach the webview
+          // (https://github.com/flutter/flutter/issues/102505).
+          if (!kIsWeb) {
+            if (event.isKeyPressed(LogicalKeyboardKey.arrowLeft) ||
+                event.isKeyPressed(LogicalKeyboardKey.arrowRight) ||
+                event.isKeyPressed(LogicalKeyboardKey.arrowUp) ||
+                event.isKeyPressed(LogicalKeyboardKey.arrowDown)) {
+              return KeyEventResult.skipRemainingHandlers;
+            }
+          }
+
+          return KeyEventResult.ignored;
+        },
+        child: WebViewWidget(
+          controller: WebViewController()
+            ..setJavaScriptMode(JavaScriptMode.unrestricted)
+            ..loadRequest(
+              Uri.parse('https://www.duckduckgo.com'),
+            ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
From the [KeyEventResult.skipRemainingHandlers](https://api.flutter.dev/flutter/widgets/KeyEventResult.html) docs:

> It will be returned to the platform embedding to be propagated to text fields and non-Flutter key event handlers on the platform.

Tested on:

- [x] Chromebook
- [x] Android with hardware keyboard (USB)
- [x] iPad with hardware keyboard (Bluetooth)

Please note that on Android and Chromebook it is possible in input fields to move the cursor beyond the last character. When moving one character back (using the left arrow key), the entire text becomes selected.